### PR TITLE
fix: add data-ciphers option to openvpn command to ensure able to connect successfullly to vpn server

### DIFF
--- a/vpngate-client
+++ b/vpngate-client
@@ -229,7 +229,8 @@ class VPN:
         command = [
             "openvpn",
             "--script-security", "2",
-            "--route-up", up
+            "--route-up", up,
+            "--data-ciphers", "AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305:AES-128-CBC"
         ]
 
         # Only use 'update-resolv-conf' in '--up' and '--down' if really exists on filesystem.


### PR DESCRIPTION
Encounter error `ERROR: failed to negotiate cipher with server.`
This pull request add option `--data-ciphers` when calling openvpn to resolve the issue.